### PR TITLE
Image fetcher

### DIFF
--- a/Utils.xcodeproj/project.pbxproj
+++ b/Utils.xcodeproj/project.pbxproj
@@ -15,7 +15,8 @@
 		B83FC6871EF06D3A00BF1173 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */; };
 		B83FC6881EF06D3A00BF1173 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6851EF06D3A00BF1173 /* Result.framework */; };
 		B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */; };
-		B8402F331F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */; };
+		B845806C1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B845806A1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift */; };
+		B845806D1F7D59370018B9A6 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -40,7 +41,8 @@
 		B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		B83FC6851EF06D3A00BF1173 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
 		B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImagePickerService.swift; path = Services/ImagePickerService.swift; sourceTree = "<group>"; };
-		B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImagePickerControllerSourceTypeExtension.swift; path = Extensions/UIImagePickerControllerSourceTypeExtension.swift; sourceTree = "<group>"; };
+		B845806A1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImagePickerControllerSourceTypeExtension.swift; sourceTree = "<group>"; };
+		B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -87,7 +89,7 @@
 		B83FC6671EF05FB300BF1173 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				B8402F341F0162500027639D /* Extensions */,
+				B84580691F7D59370018B9A6 /* Extensions */,
 				B83FC67F1EF0640B00BF1173 /* Services */,
 				B83FC6681EF05FB300BF1173 /* Utils.h */,
 				B83FC6691EF05FB300BF1173 /* Info.plist */,
@@ -123,12 +125,13 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
-		B8402F341F0162500027639D /* Extensions */ = {
+		B84580691F7D59370018B9A6 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
-				B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */,
+				B845806A1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift */,
+				B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */,
 			);
-			name = Extensions;
+			path = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -263,8 +266,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B83FC6811EF0641E00BF1173 /* ImageFetcher.swift in Sources */,
-				B8402F331F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift in Sources */,
+				B845806D1F7D59370018B9A6 /* URLSessionExtension.swift in Sources */,
+				B845806C1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift in Sources */,
 				B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */,
 				B80AA66F1EFAD8F200FC46A9 /* ImageFetcher.swift in Sources */,
 			);

--- a/Utils.xcodeproj/project.pbxproj
+++ b/Utils.xcodeproj/project.pbxproj
@@ -7,10 +7,10 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B80AA66F1EFAD8F200FC46A9 /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B80AA66E1EFAD8F200FC46A9 /* ImageFetcher.swift */; };
 		B83FC66F1EF05FB300BF1173 /* Utils.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6651EF05FB300BF1173 /* Utils.framework */; };
 		B83FC6741EF05FB300BF1173 /* UtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83FC6731EF05FB300BF1173 /* UtilsTests.swift */; };
 		B83FC6761EF05FB300BF1173 /* Utils.h in Headers */ = {isa = PBXBuildFile; fileRef = B83FC6681EF05FB300BF1173 /* Utils.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B83FC6811EF0641E00BF1173 /* ImageFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83FC6801EF0641E00BF1173 /* ImageFetcher.swift */; };
 		B83FC6861EF06D3A00BF1173 /* ReactiveCocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6831EF06D3A00BF1173 /* ReactiveCocoa.framework */; };
 		B83FC6871EF06D3A00BF1173 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */; };
 		B83FC6881EF06D3A00BF1173 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6851EF06D3A00BF1173 /* Result.framework */; };
@@ -29,13 +29,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		B80AA66E1EFAD8F200FC46A9 /* ImageFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageFetcher.swift; path = Services/ImageFetcher.swift; sourceTree = "<group>"; };
 		B83FC6651EF05FB300BF1173 /* Utils.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Utils.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B83FC6681EF05FB300BF1173 /* Utils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Utils.h; sourceTree = "<group>"; };
 		B83FC6691EF05FB300BF1173 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B83FC66E1EF05FB300BF1173 /* UtilsTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = UtilsTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		B83FC6731EF05FB300BF1173 /* UtilsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UtilsTests.swift; sourceTree = "<group>"; };
 		B83FC6751EF05FB300BF1173 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		B83FC6801EF0641E00BF1173 /* ImageFetcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImageFetcher.swift; path = Services/ImageFetcher.swift; sourceTree = "<group>"; };
 		B83FC6831EF06D3A00BF1173 /* ReactiveCocoa.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveCocoa.framework; path = Carthage/Build/iOS/ReactiveCocoa.framework; sourceTree = "<group>"; };
 		B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		B83FC6851EF06D3A00BF1173 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
@@ -107,7 +107,7 @@
 		B83FC67F1EF0640B00BF1173 /* Services */ = {
 			isa = PBXGroup;
 			children = (
-				B83FC6801EF0641E00BF1173 /* ImageFetcher.swift */,
+				B80AA66E1EFAD8F200FC46A9 /* ImageFetcher.swift */,
 				B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */,
 			);
 			name = Services;
@@ -266,6 +266,7 @@
 				B83FC6811EF0641E00BF1173 /* ImageFetcher.swift in Sources */,
 				B8402F331F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift in Sources */,
 				B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */,
+				B80AA66F1EFAD8F200FC46A9 /* ImageFetcher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Utils/Extensions/URLSessionExtension.swift
+++ b/Utils/Extensions/URLSessionExtension.swift
@@ -1,0 +1,19 @@
+//
+//  URLSessionExtension.swift
+//  Utils
+//
+//  Created by Nahuel Gladstein on 6/26/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import Foundation
+
+public extension URLSession {
+    
+    public static func cacheSession() -> URLSession {
+        let configuration = URLSessionConfiguration.default
+        configuration.requestCachePolicy = .returnCacheDataElseLoad
+        return URLSession(configuration: configuration)
+    }
+    
+}

--- a/Utils/Extensions/URLSessionExtension.swift
+++ b/Utils/Extensions/URLSessionExtension.swift
@@ -10,6 +10,9 @@ import Foundation
 
 public extension URLSession {
     
+    /**
+     Returns a URLSession that uses .returnCacheDataElseLoad as cache policy.
+     */
     public static func cacheSession() -> URLSession {
         let configuration = URLSessionConfiguration.default
         configuration.requestCachePolicy = .returnCacheDataElseLoad

--- a/Utils/Services/ImageFetcher.swift
+++ b/Utils/Services/ImageFetcher.swift
@@ -1,0 +1,42 @@
+//
+//  ImageFetcher.swift
+//  Utils
+//
+//  Created by Nahuel Gladstein on 6/13/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import UIKit
+import ReactiveSwift
+
+public protocol ImageFetcherType {
+    
+    func fetchImage(_ imageURL: URL) -> SignalProducer<UIImage, ImageFetcherError>
+    
+}
+
+public enum ImageFetcherError: Error {
+    case invalidImageFormat
+    case fetchError(Error)
+}
+
+public class ImageFetcher: ImageFetcherType {
+    
+    /**
+     Fetches an image asynchronously from a URL, returning a value or an error in the SignalProducer when done.
+     - parameter imageURL: the url of the image to fetch.
+     */
+    public func fetchImage(_ imageURL: URL) -> SignalProducer<UIImage, ImageFetcherError> {
+        return URLSession.shared
+            .reactive.data(with: URLRequest(url: imageURL))
+            .flatMapError { SignalProducer(error: .fetchError($0)) }
+            .flatMap(.concat) { data, _ -> SignalProducer<UIImage, ImageFetcherError> in
+                if let image = UIImage(data: data) {
+                    return SignalProducer(value: image)
+                } else {
+                    return SignalProducer(error: .invalidImageFormat)
+                }
+        }
+    }
+    
+}

--- a/Utils/Services/ImageFetcher.swift
+++ b/Utils/Services/ImageFetcher.swift
@@ -14,18 +14,28 @@ public protocol ImageFetcherType {
     /**
      Fetches an image asynchronously from a URL, returning a value or an error in the SignalProducer when done.
      - parameter imageURL: the url of the image to fetch.
-     - parameter session: the URLSession to use to make the request. Default: URLSession.shared.
-     You can use URLSession.cacheSession to use .returnCacheDataElseLoad cache policy.
-     */
+     - parameter session: the URLSession to use to make the request.
+     - note: You can use URLSession.cacheSession to use .returnCacheDataElseLoad cache policy.
+    */
     func fetchImage(_ imageURL: URL, with session: URLSession) -> SignalProducer<UIImage, ImageFetcherError>
     
 }
 
+/**
+ Enum that represents possible errors from trying to fetch an image.
+ It includes:
+ a successful fetch but whose result file is not an image 
+ a problem in the communication with an Error associated that gives more information (this may include no internet connection or inexistent URL).
+*/
 public enum ImageFetcherError: Error {
     case invalidImageFormat
     case fetchError(Error)
 }
 
+/**
+ Class for fetching images through ImageFetcherType protocol.
+ It uses the shared URLSession by default.
+*/
 public class ImageFetcher: ImageFetcherType {
     
     public func fetchImage(_ imageURL: URL, with session: URLSession = URLSession.shared) -> SignalProducer<UIImage, ImageFetcherError> {

--- a/Utils/Services/ImageFetcher.swift
+++ b/Utils/Services/ImageFetcher.swift
@@ -11,6 +11,12 @@ import ReactiveSwift
 
 public protocol ImageFetcherType {
     
+    /**
+     Fetches an image asynchronously from a URL, returning a value or an error in the SignalProducer when done.
+     - parameter imageURL: the url of the image to fetch.
+     - parameter session: the URLSession to use to make the request. Default: URLSession.shared.
+     You can use URLSession.cacheSession to use .returnCacheDataElseLoad cache policy.
+     */
     func fetchImage(_ imageURL: URL, with session: URLSession) -> SignalProducer<UIImage, ImageFetcherError>
     
 }
@@ -22,12 +28,6 @@ public enum ImageFetcherError: Error {
 
 public class ImageFetcher: ImageFetcherType {
     
-    /**
-     Fetches an image asynchronously from a URL, returning a value or an error in the SignalProducer when done.
-     - parameter imageURL: the url of the image to fetch.
-     - parameter session: the URLSession to use to make the request. Default: URLSession.shared
-        You can use URLSession.cacheSession to use .returnCacheDataElseLoad cache policy.
-     */
     public func fetchImage(_ imageURL: URL, with session: URLSession = URLSession.shared) -> SignalProducer<UIImage, ImageFetcherError> {
         return session
             .reactive.data(with: URLRequest(url: imageURL))

--- a/Utils/Services/ImageFetcher.swift
+++ b/Utils/Services/ImageFetcher.swift
@@ -11,7 +11,7 @@ import ReactiveSwift
 
 public protocol ImageFetcherType {
     
-    func fetchImage(_ imageURL: URL) -> SignalProducer<UIImage, ImageFetcherError>
+    func fetchImage(_ imageURL: URL, with session: URLSession) -> SignalProducer<UIImage, ImageFetcherError>
     
 }
 
@@ -25,12 +25,14 @@ public class ImageFetcher: ImageFetcherType {
     /**
      Fetches an image asynchronously from a URL, returning a value or an error in the SignalProducer when done.
      - parameter imageURL: the url of the image to fetch.
+     - parameter session: the URLSession to use to make the request. Default: URLSession.shared
+        You can use URLSession.cacheSession to use .returnCacheDataElseLoad cache policy.
      */
-    public func fetchImage(_ imageURL: URL) -> SignalProducer<UIImage, ImageFetcherError> {
-        return URLSession.shared
+    public func fetchImage(_ imageURL: URL, with session: URLSession = URLSession.shared) -> SignalProducer<UIImage, ImageFetcherError> {
+        return session
             .reactive.data(with: URLRequest(url: imageURL))
             .flatMapError { SignalProducer(error: .fetchError($0)) }
-            .flatMap(.concat) { data, _ -> SignalProducer<UIImage, ImageFetcherError> in
+            .flatMap(.concat) { data, response -> SignalProducer<UIImage, ImageFetcherError> in                
                 if let image = UIImage(data: data) {
                     return SignalProducer(value: image)
                 } else {


### PR DESCRIPTION
**Issue:** https://github.com/Wolox/wolmo-utils-ios/issues/2

Added an `ImageFetcher` that asynchronously fetchs an image from a URL and returns a `SignalProducer`.
It also has a protocol, the user should use it as the type to be able to mock the service when testing code that depends on the fetcher.