### PR TITLE
ImagePickerService

### DIFF
--- a/Utils.xcodeproj/project.pbxproj
+++ b/Utils.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		B83FC6871EF06D3A00BF1173 /* ReactiveSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */; };
 		B83FC6881EF06D3A00BF1173 /* Result.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B83FC6851EF06D3A00BF1173 /* Result.framework */; };
 		B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */; };
+		B8402F331F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -39,6 +40,7 @@
 		B83FC6841EF06D3A00BF1173 /* ReactiveSwift.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = ReactiveSwift.framework; path = Carthage/Build/iOS/ReactiveSwift.framework; sourceTree = "<group>"; };
 		B83FC6851EF06D3A00BF1173 /* Result.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Result.framework; path = Carthage/Build/iOS/Result.framework; sourceTree = "<group>"; };
 		B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImagePickerService.swift; path = Services/ImagePickerService.swift; sourceTree = "<group>"; };
+		B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = UIImagePickerControllerSourceTypeExtension.swift; path = Extensions/UIImagePickerControllerSourceTypeExtension.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -85,6 +87,7 @@
 		B83FC6671EF05FB300BF1173 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				B8402F341F0162500027639D /* Extensions */,
 				B83FC67F1EF0640B00BF1173 /* Services */,
 				B83FC6681EF05FB300BF1173 /* Utils.h */,
 				B83FC6691EF05FB300BF1173 /* Info.plist */,
@@ -118,6 +121,14 @@
 				B83FC6851EF06D3A00BF1173 /* Result.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		B8402F341F0162500027639D /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				B8402F321F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift */,
+			);
+			name = Extensions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -253,6 +264,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				B83FC6811EF0641E00BF1173 /* ImageFetcher.swift in Sources */,
+				B8402F331F0161730027639D /* UIImagePickerControllerSourceTypeExtension.swift in Sources */,
 				B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Utils/Extensions/UIImagePickerControllerSourceTypeExtension.swift
+++ b/Utils/Extensions/UIImagePickerControllerSourceTypeExtension.swift
@@ -1,0 +1,56 @@
+//
+//  UIImagePickerControllerSourceTypeExtension.swift
+//  Utils
+//
+//  Created by Nahuel Gladstein on 6/26/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import Foundation
+import ReactiveSwift
+import AVFoundation
+import Photos
+import Result
+
+internal extension UIImagePickerControllerSourceType {
+    
+    internal func isPermitted() -> SignalProducer<Bool, ImagePickerServiceError> {
+        switch self {
+        case .camera:
+            guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return SignalProducer(error: .sourceTypeNotAvailable) }
+            return hasCameraPermission()
+        case .photoLibrary, .savedPhotosAlbum: return hasPhotosPermission()
+        }
+    }
+    
+}
+
+fileprivate extension UIImagePickerControllerSourceType {
+
+    fileprivate func hasCameraPermission() -> SignalProducer<Bool, ImagePickerServiceError> {
+        return SignalProducer { observable, _ in
+            switch AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo) {
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo) {
+                    observable.send(value: $0)
+                }
+            case .authorized: observable.send(value: true)
+            case .denied, .restricted: observable.send(value: false)
+            }
+        }
+    }
+    
+    fileprivate func hasPhotosPermission() -> SignalProducer<Bool, ImagePickerServiceError> {
+        return SignalProducer { observable, _ in
+            switch PHPhotoLibrary.authorizationStatus() {
+            case .notDetermined:
+                PHPhotoLibrary.requestAuthorization {
+                    observable.send(value: $0 == .authorized)
+                }
+            case .authorized: observable.send(value: true)
+            case .denied, .restricted: observable.send(value: false)
+            }
+        }
+    }
+    
+}

--- a/Utils/Services/ImagePickerService.swift
+++ b/Utils/Services/ImagePickerService.swift
@@ -1,0 +1,141 @@
+//
+//  ImagePickerService.swift
+//  Utils
+//
+//  Created by Nahuel Gladstein on 6/13/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import ReactiveSwift
+import UIKit
+import AVFoundation
+import Photos
+import Result
+
+public enum ImagePickerServiceError: Error {
+    
+    case sourceTypeNotAvailable
+    
+}
+
+public protocol ImagePickerServiceType {
+    /**
+     Observe imageSignal to get the UIImage selected by the user
+     */
+    var imageSignal: Signal<UIImage, ImagePickerServiceError> { get }
+    
+    /**
+     Presents the camera to the user so it can take a picture. If the user didn't give permission to the app to use the camera
+        a prompt asking it will be shown.
+     - parameter permissionNotGranted: Block called when the user denies permission. If the user gives permission the camera will be shown.
+     */
+    func presentCameraTypeImagePickerController(_ permissionNotGranted: @escaping (Void) -> Void)
+    
+    /**
+     Presents the media library to the user so it can select a picture. If the user didn't give permission to the app to use the library
+        a prompt asking it will be shown.
+     - parameter permissionNotGranted: Block called when the user denies permission. If the user gives permission the library will be shown.
+     */
+    func presentGalleryTypeImagePickerController(_ permissionNotGranted: @escaping (Void) -> Void)
+    
+    /**
+     Tells if the device has a camera.
+     */
+    var cameraIsAvailable: Bool { get }
+}
+
+@objc
+public final class ImagePickerService: NSObject, ImagePickerServiceType {
+    
+    public let imageSignal: Signal<UIImage, ImagePickerServiceError>
+    fileprivate let _imageObserver: Signal<UIImage, ImagePickerServiceError>.Observer
+    
+    fileprivate weak var _viewController: UIViewController?
+    
+    init(viewController: UIViewController) {
+        _viewController = viewController
+        (imageSignal, _imageObserver) = Signal<UIImage, ImagePickerServiceError>.pipe()
+    }
+    
+    public func presentCameraTypeImagePickerController(_ permissionNotGranted: @escaping (Void) -> Void) {
+        if cameraIsAvailable {
+            hasCameraPermission().startWithValues { [unowned self] in
+                $0 ? self.presentImagePickerController(.camera) : permissionNotGranted()
+            }
+        } else {
+            _imageObserver.send(error: ImagePickerServiceError.sourceTypeNotAvailable)
+        }
+    }
+    
+    public func presentGalleryTypeImagePickerController(_ permissionNotGranted: @escaping (Void) -> Void) {
+        hasPhotosPermission().startWithValues { [unowned self] in
+            $0 ? self.presentImagePickerController(.photoLibrary) : permissionNotGranted()
+        }
+    }
+    
+    public var cameraIsAvailable: Bool {
+        return UIImagePickerController.isSourceTypeAvailable(.camera)
+    }
+    
+    deinit {
+        _imageObserver.sendCompleted()
+    }
+}
+
+fileprivate extension ImagePickerService {
+    
+    fileprivate func hasCameraPermission() -> SignalProducer<Bool, NoError> {
+        return SignalProducer { observable, _ in
+            switch AVCaptureDevice.authorizationStatus(forMediaType: AVMediaTypeVideo) {
+            case .notDetermined:
+                AVCaptureDevice.requestAccess(forMediaType: AVMediaTypeVideo) {
+                    observable.send(value: $0)
+                }
+            case .authorized: observable.send(value: true)
+            case .denied, .restricted: observable.send(value: false)
+            }
+        }
+    }
+    
+    fileprivate func hasPhotosPermission() -> SignalProducer<Bool, NoError> {
+        return SignalProducer { observable, _ in
+            switch PHPhotoLibrary.authorizationStatus() {
+            case .notDetermined:
+                PHPhotoLibrary.requestAuthorization {
+                    observable.send(value: $0 == .authorized)
+                }
+            case .authorized: observable.send(value: true)
+            case .denied, .restricted: observable.send(value: false)
+            }
+        }
+    }
+    
+}
+
+extension ImagePickerService: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    
+    public func imagePickerController(_ picker: UIImagePickerController,
+                               didFinishPickingImage image: UIImage, editingInfo: [String : AnyObject]?) {
+        _viewController?.dismiss(animated: true) { [unowned self] in
+            self._imageObserver.send(value: image)
+        }
+    }
+    
+    public func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+        _viewController?.dismiss(animated: true, completion: nil)
+    }
+    
+}
+
+fileprivate extension ImagePickerService {
+    
+    fileprivate func presentImagePickerController(_ sourceType: UIImagePickerControllerSourceType) {
+        let imagePickerController = UIImagePickerController()
+        imagePickerController.delegate = self
+        imagePickerController.allowsEditing = true
+        imagePickerController.sourceType = sourceType
+        
+        _viewController?.present(imagePickerController, animated: true, completion: nil)
+    }
+    
+}


### PR DESCRIPTION
**Issue**:https://github.com/Wolox/wolmo-utils-ios/issues/4

Added an ImagePickerService to handle the permission and presentation of an image picker, be it a library or camera one.
Also added a protocol so the user can mock the service when testing a class that uses it.
