### PR TITLE
Adding video and other type media to picker

### DIFF
--- a/Utils/Extensions/UIImagePickerControllerSourceTypeExtension.swift
+++ b/Utils/Extensions/UIImagePickerControllerSourceTypeExtension.swift
@@ -14,7 +14,7 @@ import Result
 
 internal extension UIImagePickerControllerSourceType {
     
-    internal func isPermitted() -> SignalProducer<Bool, ImagePickerServiceError> {
+    internal func isPermitted() -> SignalProducer<Bool, MediaPickerServiceError> {
         switch self {
         case .camera:
             guard UIImagePickerController.isSourceTypeAvailable(.camera) else { return SignalProducer(error: .sourceTypeNotAvailable) }
@@ -27,7 +27,7 @@ internal extension UIImagePickerControllerSourceType {
 
 fileprivate extension UIImagePickerControllerSourceType {
 
-    fileprivate func hasCameraPermission() -> SignalProducer<Bool, ImagePickerServiceError> {
+    fileprivate func hasCameraPermission() -> SignalProducer<Bool, MediaPickerServiceError> {
         return SignalProducer { observable, _ in
             switch AVCaptureDevice.authorizationStatus(for: AVMediaType.video) {
             case .notDetermined:
@@ -40,7 +40,7 @@ fileprivate extension UIImagePickerControllerSourceType {
         }
     }
     
-    fileprivate func hasPhotosPermission() -> SignalProducer<Bool, ImagePickerServiceError> {
+    fileprivate func hasPhotosPermission() -> SignalProducer<Bool, MediaPickerServiceError> {
         return SignalProducer { observable, _ in
             switch PHPhotoLibrary.authorizationStatus() {
             case .notDetermined:

--- a/Utils/Services/ImagePickerService.swift
+++ b/Utils/Services/ImagePickerService.swift
@@ -79,19 +79,14 @@ extension ImagePickerService: UIImagePickerControllerDelegate, UINavigationContr
 
     public func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any]) {
         _viewController?.dismiss(animated: true) { [unowned self] in
-            let type = info[UIImagePickerControllerMediaType] as! String
-            let ImageType = (kUTTypeImage as NSString) as String
-            let VideoType = (kUTTypeMovie as NSString) as String
+            let type = info[UIImagePickerControllerMediaType] as! CFString
 
-            switch type {
-            case ImageType: self._imageObserver.send(value: .image(self.getImage(from: info)!))
-            case VideoType: self._imageObserver.send(value: .video(info[UIImagePickerControllerMediaURL] as! URL))
-            default:
-                if let image = self.getImage(from: info) {
-                    self._imageObserver.send(value: .image(image))
-                } else {
-                    self._imageObserver.send(value: .other(info))
-                }
+            if UTTypeConformsTo(type, kUTTypeImage) {
+                self._imageObserver.send(value: .image(self.getImage(from: info)!))
+            } else if UTTypeConformsTo(type, kUTTypeAudiovisualContent) {
+                self._imageObserver.send(value: .video(info[UIImagePickerControllerMediaURL] as! URL))
+            } else {
+                self._imageObserver.send(value: .other(info))
             }
         }
     }

--- a/Utils/Services/ImagePickerService.swift
+++ b/Utils/Services/ImagePickerService.swift
@@ -16,12 +16,30 @@ public enum ImagePickerServiceError: Error {
     
 }
 
+/**
+ Enum to represent all media types an UIImagePickerController can get.
+ For full details, please visit: https://developer.apple.com/documentation/mobilecoreservices/uttype
+ */
+public enum ImagePickerMediaType {
+    case image
+    case video
+    case other(CFString)
+}
+
+/**
+ Enum to represent all possible medias an UIImagePickerController can get.
+ Some types are particularly identified, for others you can use its dictionary to get information.
+ For more information refer to `func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [String : Any])`.
+ */
 public enum ImagePickerMedia {
     case image(UIImage)
     case video(URL)
     case other([String : Any])
 }
 
+/**
+ Service that provides a way to get media.
+ */
 public protocol ImagePickerServiceType {
     /**
      Observe imageSignal to get the ImagePickerMedia selected by the user
@@ -29,12 +47,14 @@ public protocol ImagePickerServiceType {
     var imageSignal: Signal<ImagePickerMedia, ImagePickerServiceError> { get }
     
     /**
-     Presents the picker to the user so it can take or select a picture. If the user didn't give permission to the app to use the source type selected
-        a prompt asking it will be shown.
+     Presents the picker to the user so it can take or select a picture or other media.
+     If the user didn't give permission to the app to use the source type selected a prompt asking it will be shown.
      - parameter source: Source type for the picker to show. Can be .camera or .photoLibrary.
      - parameter onPermissionNotGranted: Block called if the user denies permission. If the user gives permission the camera will be shown.
      */
-    func presentImagePickerController(for source: UIImagePickerControllerSourceType, _ onPermissionNotGranted: @escaping () -> Void)
+    func presentImagePickerController(from source: UIImagePickerControllerSourceType,
+                                      for media: [ImagePickerMediaType],
+                                      _ onPermissionNotGranted: @escaping () -> Void)
     
     /**
      Tells if the device has a camera.
@@ -55,11 +75,13 @@ public final class ImagePickerService: NSObject, ImagePickerServiceType {
         (imageSignal, _imageObserver) = Signal<ImagePickerMedia, ImagePickerServiceError>.pipe()
     }
     
-    public func presentImagePickerController(for source: UIImagePickerControllerSourceType, _ onPermissionNotGranted: @escaping () -> Void) {
+    public func presentImagePickerController(from source: UIImagePickerControllerSourceType,
+                                             for media: [ImagePickerMediaType],
+                                             _ onPermissionNotGranted: @escaping () -> Void) {
         source.isPermitted().startWithResult { [unowned self] in
             switch $0 {
             case .success(let permitted):
-                if permitted { self.presentImagePickerController(source) }
+                if permitted { self.presentImagePickerController(source: source, media: media) }
                 else { onPermissionNotGranted() }
             case .failure(let error): self._imageObserver.send(error: error)
             }
@@ -81,9 +103,9 @@ extension ImagePickerService: UIImagePickerControllerDelegate, UINavigationContr
         _viewController?.dismiss(animated: true) { [unowned self] in
             let type = info[UIImagePickerControllerMediaType] as! CFString
 
-            if UTTypeConformsTo(type, kUTTypeImage) {
+            if UTTypeConformsTo(type, ImagePickerMediaType.image.mediaTypeString) {
                 self._imageObserver.send(value: .image(self.getImage(from: info)!))
-            } else if UTTypeConformsTo(type, kUTTypeAudiovisualContent) {
+            } else if UTTypeConformsTo(type, ImagePickerMediaType.video.mediaTypeString) {
                 self._imageObserver.send(value: .video(info[UIImagePickerControllerMediaURL] as! URL))
             } else {
                 self._imageObserver.send(value: .other(info))
@@ -106,13 +128,26 @@ extension ImagePickerService: UIImagePickerControllerDelegate, UINavigationContr
 
 fileprivate extension ImagePickerService {
     
-    fileprivate func presentImagePickerController(_ sourceType: UIImagePickerControllerSourceType) {
+    fileprivate func presentImagePickerController(source sourceType: UIImagePickerControllerSourceType, media mediaTypes: [ImagePickerMediaType]) {
         let imagePickerController = UIImagePickerController()
         imagePickerController.delegate = self
         imagePickerController.allowsEditing = true
         imagePickerController.sourceType = sourceType
+        imagePickerController.mediaTypes = mediaTypes.map { ($0.mediaTypeString as NSString) as String }
         
         _viewController?.present(imagePickerController, animated: true, completion: .none)
     }
     
+}
+
+fileprivate extension ImagePickerMediaType {
+
+    fileprivate var mediaTypeString: CFString {
+        switch self {
+        case .image: return kUTTypeImage
+        case .video: return kUTTypeAudiovisualContent
+        case .other(let typeString): return typeString
+        }
+    }
+
 }


### PR DESCRIPTION
Adding other types of media to picker.
There are many many types: https://developer.apple.com/documentation/mobilecoreservices/uttype
So I left the `other` open option to catch any information needed.