### PR TITLE
Add UserManager and its related classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ WolMo - Utils iOS is a framework which provides specific utilities for iOS used 
   * [Usage](#usage)
     * [ImageFetcher](#image-fetcher)
     * [ImagePickerService](#image-picker-service)
+    * [UserManager] (#user-manager)
   * [Contributing](#contributing)
   * [About](#about)
   * [License](#license)
@@ -47,6 +48,22 @@ If the user denies permission, `ImagePickerService` provides a block that you ca
 The resulting image will be returned in the public signal `imageSignal`.  
 Also you can check if the device has an available camera checking the boolean `cameraAvailable`.  
 As with the other utils, a protocol is provided and implemented by this class (`ImagePickerServiceType`) so you can use it as your type and provide a mock implementation if needed.
+
+### User Manager
+
+The framework provides a [UserManager](Utils/UserManager/UserManager.swift) intended to manage the current user. It also stores the user session exposing a way to update it whenever the user logs in, logs out, updates and expires. These transitions are expected to be handled outside the framework, but always letting UserManager know about them.
+
+When a user is logged in or signed up, `login:` must be called providing the fetched user. This will make `UserManager` know a valid session is being used.
+
+The same way, when the user is logged out, `logout` must be called. This will make `UserManager` remove the stored session token.
+
+The function `update:` receiving a user can be useful to make `UsenManager` store an updated `User`.
+
+### Storing a User
+
+`UserManager` can provide the current user reading the property `currentUser`. This property is set when `bootstrapSession` is called, which must be called only once. 
+
+This function fetches the current user if an instance of [CurrentUserFetcherType](Utils/UserManager/CurrentUserFetcher.swift) is provided. Since the user is not persisted in the device, and only stored in memory the user needs to be fetched every time the application is launched.
 
 ## Contributing
 1. Fork it

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ WolMo - Utils iOS is a framework which provides specific utilities for iOS used 
   * [Usage](#usage)
     * [ImageFetcher](#image-fetcher)
     * [ImagePickerService](#image-picker-service)
-    * [UserManager] (#user-manager)
+    * [UserManager](#user-manager)
   * [Contributing](#contributing)
   * [About](#about)
   * [License](#license)

--- a/Utils.xcodeproj/project.pbxproj
+++ b/Utils.xcodeproj/project.pbxproj
@@ -17,6 +17,10 @@
 		B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */; };
 		B845806C1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B845806A1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift */; };
 		B845806D1F7D59370018B9A6 /* URLSessionExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */; };
+		B86316312204B231009E1EB9 /* UserManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86316302204B231009E1EB9 /* UserManager.swift */; };
+		B86316332204B27D009E1EB9 /* KeychainService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86316322204B27D009E1EB9 /* KeychainService.swift */; };
+		B86316352204B2B8009E1EB9 /* CurrentUserFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86316342204B2B8009E1EB9 /* CurrentUserFetcher.swift */; };
+		B86316372204B2D0009E1EB9 /* AuthenticableUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = B86316362204B2D0009E1EB9 /* AuthenticableUser.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -43,6 +47,10 @@
 		B83FC68A1EF071BB00BF1173 /* ImagePickerService.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ImagePickerService.swift; path = Services/ImagePickerService.swift; sourceTree = "<group>"; };
 		B845806A1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImagePickerControllerSourceTypeExtension.swift; sourceTree = "<group>"; };
 		B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = URLSessionExtension.swift; sourceTree = "<group>"; };
+		B86316302204B231009E1EB9 /* UserManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserManager.swift; sourceTree = "<group>"; };
+		B86316322204B27D009E1EB9 /* KeychainService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainService.swift; sourceTree = "<group>"; };
+		B86316342204B2B8009E1EB9 /* CurrentUserFetcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentUserFetcher.swift; sourceTree = "<group>"; };
+		B86316362204B2D0009E1EB9 /* AuthenticableUser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticableUser.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -89,6 +97,7 @@
 		B83FC6671EF05FB300BF1173 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				B863162F2204B206009E1EB9 /* UserManager */,
 				B84580691F7D59370018B9A6 /* Extensions */,
 				B83FC67F1EF0640B00BF1173 /* Services */,
 				B83FC6681EF05FB300BF1173 /* Utils.h */,
@@ -132,6 +141,17 @@
 				B845806B1F7D59370018B9A6 /* URLSessionExtension.swift */,
 			);
 			path = Extensions;
+			sourceTree = "<group>";
+		};
+		B863162F2204B206009E1EB9 /* UserManager */ = {
+			isa = PBXGroup;
+			children = (
+				B86316302204B231009E1EB9 /* UserManager.swift */,
+				B86316322204B27D009E1EB9 /* KeychainService.swift */,
+				B86316342204B2B8009E1EB9 /* CurrentUserFetcher.swift */,
+				B86316362204B2D0009E1EB9 /* AuthenticableUser.swift */,
+			);
+			path = UserManager;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -248,8 +268,12 @@
 			files = (
 				B845806D1F7D59370018B9A6 /* URLSessionExtension.swift in Sources */,
 				B845806C1F7D59370018B9A6 /* UIImagePickerControllerSourceTypeExtension.swift in Sources */,
+				B86316372204B2D0009E1EB9 /* AuthenticableUser.swift in Sources */,
 				B83FC68B1EF071BB00BF1173 /* ImagePickerService.swift in Sources */,
+				B86316312204B231009E1EB9 /* UserManager.swift in Sources */,
 				B80AA66F1EFAD8F200FC46A9 /* ImageFetcher.swift in Sources */,
+				B86316352204B2B8009E1EB9 /* CurrentUserFetcher.swift in Sources */,
+				B86316332204B27D009E1EB9 /* KeychainService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Utils/UserManager/AuthenticableUser.swift
+++ b/Utils/UserManager/AuthenticableUser.swift
@@ -1,0 +1,24 @@
+//
+//  AuthenticableUser.swift
+//  Networking
+//
+//  Created by Pablo Giorgi on 1/23/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import Foundation
+
+/**
+ Represents a user fetched from API.
+ It stores a session token as an optional value, since it's expected to
+ be received when the user is received from a new session (login or signup)
+ and not in case the user is fetched using an implementation of `CurrentUserFetcherType`
+ */
+public protocol AuthenticableUser {
+    
+    // TODO: This should be refactored.
+    // Probably as a struct that holds a sessionToken and a user.
+    // sessionToken should not be part of the user properties.
+    var sessionToken: String? { get }
+    
+}

--- a/Utils/UserManager/CurrentUserFetcher.swift
+++ b/Utils/UserManager/CurrentUserFetcher.swift
@@ -1,0 +1,21 @@
+//
+//  CurrentUserFetcherType.swift
+//  Networking
+//
+//  Created by Pablo Giorgi on 3/2/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import ReactiveSwift
+
+/**
+ Protocol to be implemented by a repository intended to fetch the current user
+ by the user manager.
+ Remember in case this protocol is implemented, it must be injected to the
+ `UserManagerType` instance by the setter `setCurrentUserFetcher:`.
+ */
+public protocol CurrentUserFetcherType {
+    
+    func fetchCurrentUser() -> SignalProducer<AuthenticableUser, RepositoryError>
+    
+}

--- a/Utils/UserManager/KeychainService.swift
+++ b/Utils/UserManager/KeychainService.swift
@@ -1,0 +1,60 @@
+//
+//  KeychainService.swift
+//  Utils
+//
+//  Created by Pablo Giorgi on 5/5/17.
+//  Copyright © 2017 Wolox. All rights reserved.
+//
+
+import KeychainSwift
+
+/**
+ Protocol for keychain service.
+ Provides a way to save, delete and query a String.
+ */
+public protocol KeychainServiceType {
+    
+    /**
+     Returns the associated value given a key
+     
+     - Parameters:
+     - key: key to get the associate value in case there is any
+     - Returns:
+     A String with the associated value
+     */
+    func get(key: String) -> String?
+    
+    /**
+     Stores the value in under the given key
+     
+     - Parameters:
+     - value: value associated to key
+     - key: key to associate the value
+     */
+    func set(value: String, forKey key: String)
+    
+    /**
+     Deletes the entry for the key
+     
+     - Parameters:
+     - key: key to delete
+     */
+    func delete(key: String)
+    
+}
+
+extension KeychainSwift: KeychainServiceType {
+    
+    public func get(key: String) -> String? {
+        return get(key)
+    }
+    
+    public func set(value: String, forKey key: String) {
+        set(value, forKey: key)
+    }
+    
+    public func delete(key: String) {
+        delete(key)
+    }
+    
+}

--- a/Utils/UserManager/UserManager.swift
+++ b/Utils/UserManager/UserManager.swift
@@ -1,0 +1,241 @@
+//
+//  UserManager.swift
+//  Utils
+//
+//  Created by Pablo Giorgi on 3/2/16.
+//  Copyright © 2016 Wolox. All rights reserved.
+//
+
+import ReactiveSwift
+import Result
+import KeychainSwift
+
+/**
+ Protocol for user manager.
+ Includes the functions to handle the different session status changes,
+ and properties to get the session properties.
+ Also notifies when the session changed.
+ */
+public protocol UserManagerType {
+    
+    /**
+     Bootstraps the session manager.
+     This function loads the session token (in case there's any)
+     and sends a session status change signal. It also fetches
+     the user (in case a user fetcher has been provided) and sends
+     a user change signal.
+     */
+    func bootstrap()
+    
+    /**
+     Returns whether there is an active session.
+     */
+    var isLoggedIn: Bool { get }
+    
+    /**
+     Returns the current session token in case there is an active session.
+     */
+    var sessionToken: String? { get }
+    
+    /**
+     Returns the current user in case there is an active session.
+     A current user fetcher must be provided for this property to have a value.
+     */
+    var currentUser: AuthenticableUser? { get }
+    
+    /**
+     Signal that notifies each time the session status changes.
+     Its value is a Bool representing whether there is an active session.
+     Useful to handle the application status based on the session status.
+     */
+    var sessionSignal: Signal<Bool, NoError> { get }
+    
+    /**
+     Signal that notifies each time the user changes.
+     Its value is a User representing the current user.
+     Useful to keep the user up to date any time it's fetched or updated.
+     */
+    var userSignal: Signal<AuthenticableUser?, NoError> { get }
+    
+    /**
+     Set the current user fecther used to fetch the user when the
+     session manager is bootstrapped.
+     Unlike the session token, the user is not stored locally
+     by the session manager. This is why it needs to be fetched
+     during the bootstrapping.
+     This should be called before bootstrap to have effect.
+     */
+    func setCurrentUserFetcher(currentUserFetcher: CurrentUserFetcherType)
+    
+    /**
+     This function must be called manually when a user is logged in.
+     It will send both a session and user notification.
+     
+     - Parameters:
+     - user: user to initialize the session from.
+     */
+    func login(user: AuthenticableUser)
+    
+    /**
+     This function can be called manually when a user is fetched from
+     outside the session manager. In case the current user is wanted
+     to be up to date with the fetched one.
+     It will send both a session and user notification.
+     
+     - Parameters:
+     - user: user to initialize the session from.
+     */
+    func update(user: AuthenticableUser)
+    
+    /**
+     This function must be called manually, apart from the server's call,
+     to log out the user.
+     It will send both a session and user notification.
+     */
+    func logout()
+    
+    /**
+     This function is called automatically by a repository when
+     the session expires and the client is notified by the server.
+     No need to be called manually.
+     It only logs out the user in the session manager and notifies.
+     */
+    func expire()
+    
+}
+
+/**
+ Default UserManager responsible for handling the session in the application.
+ It uses Keychain to store securely the session token in local storage, and a repository
+ to fetch the user when it's bootstrapped.
+ */
+final public class UserManager: UserManagerType {
+    fileprivate let _keychainService: KeychainServiceType
+    fileprivate var _currentUserFetcher: CurrentUserFetcherType?
+    
+    fileprivate let _sessionToken = MutableProperty<String?>(.none)
+    fileprivate let _currentUser = MutableProperty<AuthenticableUser?>(.none)
+    
+    public init(keychainService: KeychainServiceType = KeychainSwift()) {
+        _keychainService = keychainService
+    }
+    
+    public func setCurrentUserFetcher(currentUserFetcher: CurrentUserFetcherType) {
+        // TODO: Check this doesn't cause a leak.
+        _currentUserFetcher = currentUserFetcher
+    }
+    
+    public func bootstrap() {
+        _sessionToken.value = getSessionToken()
+        if let currentUserFetcher = _currentUserFetcher, isLoggedIn {
+            currentUserFetcher.fetchCurrentUser().startWithResult { [unowned self] in
+                switch $0 {
+                case .success(let user): self._currentUser.value = user
+                case .failure: break // TODO: Handle error here.
+                }
+            }
+        } else {
+            _currentUser.value = .none
+        }
+    }
+    
+    public var isLoggedIn: Bool {
+        return sessionToken != .none
+    }
+    
+}
+
+public extension UserManager {
+    
+    var sessionToken: String? {
+        return _sessionToken.value
+    }
+    
+    var currentUser: AuthenticableUser? {
+        return _currentUser.value
+    }
+    
+    var sessionSignal: Signal<Bool, NoError> {
+        return _sessionToken.signal.map { $0 != .none }
+    }
+    
+    var userSignal: Signal<AuthenticableUser?, NoError> {
+        return _currentUser.signal
+    }
+    
+}
+
+public extension UserManager {
+    
+    public func login(user: AuthenticableUser) {
+        guard !isLoggedIn else {
+            fatalError("Attempting to login an already logged in session in SessionManager")
+        }
+        saveSessionToken(user: user)
+        saveUser(user: user)
+    }
+    
+    public func update(user: AuthenticableUser) {
+        guard isLoggedIn else {
+            fatalError("Attempting to update a non logged in session in SessionManager")
+        }
+        saveSessionToken(user: user)
+        saveUser(user: user)
+    }
+    
+    public func logout() {
+        guard isLoggedIn else {
+            fatalError("Attempting to logout a non logged in session in SessionManager")
+        }
+        clearSession()
+    }
+    
+    public func expire() {
+        guard isLoggedIn else {
+            fatalError("Attempting to expire a non logged in session in SessionManager")
+        }
+        clearSession()
+    }
+    
+}
+
+private extension UserManager {
+    
+    func clearSession() {
+        _sessionToken.value = .none
+        _currentUser.value = .none
+        clearSessionToken()
+    }
+    
+    func saveSessionToken(user: AuthenticableUser) {
+        _sessionToken.value = user.sessionToken
+        if let sessionToken = user.sessionToken {
+            saveSessionToken(sessionToken: sessionToken)
+        } else {
+            fatalError("Authenticated user has no session token, unable to save session in SessionManager")
+        }
+    }
+    
+    func saveUser(user: AuthenticableUser) {
+        _currentUser.value = user
+    }
+    
+}
+
+private extension UserManager {
+    
+    private static let CurrentSessionTokenPersistanceKey = "com.wolox.wolmo-networking.CurrentSessionToken"
+    
+    func getSessionToken() -> String? {
+        return _keychainService.get(key: UserManager.CurrentSessionTokenPersistanceKey)
+    }
+    
+    func saveSessionToken(sessionToken: String) {
+        _keychainService.set(value: sessionToken, forKey: UserManager.CurrentSessionTokenPersistanceKey)
+    }
+    
+    func clearSessionToken() {
+        _keychainService.delete(key: UserManager.CurrentSessionTokenPersistanceKey)
+    }
+    
+}


### PR DESCRIPTION
Moved UserManager, CurrentUserFetcher, AuthenticableUser and KeychainService to Utils, they were in Networking but it made no sense. 

These 4 classes are meant to be used together, but we could isolate them to make copy-pasting easier if we feel that's needed.

CurrentUserFetcher and AuthenticableUser we could delete, those classes are not adding a lot.
Discussion is open. Add whoever you want to the PR.